### PR TITLE
fix urls with port

### DIFF
--- a/src/Service/AbstractService.php
+++ b/src/Service/AbstractService.php
@@ -67,8 +67,7 @@ abstract class AbstractService
         }
 
         if (!empty($config['host'])) {
-            $url = parse_url($config['host']);
-            $config['host'] = "{$url['scheme']}://{$url['host']}";
+            $config['host'] = rtrim($config['host'], '/');
         } else {
             $config['host'] = rtrim($this->getDefaultHost(), '/');
         }


### PR DESCRIPTION
В случае если в адресе присутствует порт, то он обрезается. Думаю можно обойтись здесь без parse_url, тем более parse_url есть в Nyholm\Psr7\Uri