### PR TITLE
fix /v4/product/info/prices request with empty filter (#65)

### DIFF
--- a/src/Service/V4/ProductService.php
+++ b/src/Service/V4/ProductService.php
@@ -19,7 +19,7 @@ class ProductService extends AbstractService
         assert($limit > 0 && $limit <= 1000);
 
         $body = [
-            'filter' => ArrayHelper::pick($filter, ['offer_id', 'product_id', 'visibility']),
+            'filter' => ArrayHelper::pick($filter, ['offer_id', 'product_id', 'visibility']) ?: new \stdClass(),
             'last_id' => $lastId ?? '',
             'limit' => $limit
         ];

--- a/tests/Service/V4/ProductServiceTest.php
+++ b/tests/Service/V4/ProductServiceTest.php
@@ -69,5 +69,12 @@ class ProductServiceTest extends AbstractTestCase
 
             '{"filter":{"offer_id":["3244378","1107890","PRD-1"],"product_id":[243686911],"visibility":"ALL"},"last_id":"","limit":100}'
         ];
+
+        $arguments['filter'] = [];
+        yield [
+            $arguments,
+
+            '{"filter":{},"last_id":"","limit":100}'
+        ];
     }
 }


### PR DESCRIPTION
Поле filter является обязательным для запроса /v4/product/info/prices, но если передавать в метод пустой массив, он будет закодирован в json как массив ([]), а api ОЗОНа ожидает объект ({}).
#65