### PR TITLE
Fix for dynamic properties deprecation in PHP 8.2

### DIFF
--- a/src/Service/AbstractService.php
+++ b/src/Service/AbstractService.php
@@ -25,6 +25,9 @@ abstract class AbstractService
 
     /** @var RequestFactoryInterface */
     protected $requestFactory;
+    
+    /** @var StreamFactoryInterface */
+    protected $streamFactory;
 
     public function __construct(array $config, ClientInterface $client, ?RequestFactoryInterface $requestFactory = null, ?StreamFactoryInterface $streamFactory = null)
     {


### PR DESCRIPTION
Based on RFC: https://wiki.php.net/rfc/deprecate_dynamic_properties.
As $this->streamFactory is not declared in the AbstractService class, it causes deprecation warning in constructor:  $this->streamFactory = $streamFactory;