### PR TITLE
[#115] replace deprecated v3 fbs orders list methods with v4

### DIFF
--- a/bin/is_realized.php
+++ b/bin/is_realized.php
@@ -27,6 +27,7 @@ use Gam6itko\OzonSeller\Service\V2\ReturnsService as V2ReturnsService;
 use Gam6itko\OzonSeller\Service\V2\WarehouseService;
 use Gam6itko\OzonSeller\Service\V3\ProductService as V3ProductService;
 use Gam6itko\OzonSeller\Service\V4\ProductService as V4ProductService;
+use Gam6itko\OzonSeller\Service\V4\Posting\FbsService as V4FbsService;
 use Gam6itko\OzonSeller\Service\V5\Posting\FbsService as V5FbsService;
 use Gam6itko\OzonSeller\Service\V5\ProductService as V5ProductService;
 use Gam6itko\OzonSeller\Service\V6\Posting\FbsService as V6FbsService;
@@ -81,6 +82,8 @@ const MAPPING = [
     '/v4/product/info/prices'                        => [V4ProductService::class, 'infoPrices'],
     '/v4/product/info/stocks'                        => [V4ProductService::class, 'infoStocks'],
     '/v4/product/info/attributes'                    => [V4ProductService::class, 'infoAttributes'],
+    '/v4/posting/fbs/list'                           => [V4FbsService::class, 'list'],
+    '/v4/posting/fbs/unfulfilled/list'               => [V4FbsService::class, 'unfulfilledList'],
 
     // V5
     '/v5/fbs/posting/product/exemplar/create-or-get' => [V5FbsService::class, 'productExemplarCreateOrGet'],

--- a/src/Service/V3/Posting/FbsService.php
+++ b/src/Service/V3/Posting/FbsService.php
@@ -18,6 +18,7 @@ class FbsService extends AbstractService implements HasOrdersInterface, HasUnful
     private $path = '/v3/posting/fbs';
 
     /**
+     * @deprecated will be removed 01.06.2026 - use V4\Posting\FbsService::list
      * @see https://docs.ozon.ru/api/seller/#operation/PostingAPI_GetFbsPostingList
      */
     public function list(array $requestData = []): array
@@ -57,6 +58,9 @@ class FbsService extends AbstractService implements HasOrdersInterface, HasUnful
         return $this->request('POST', "{$this->path}/list", $requestData);
     }
 
+    /**
+     * @deprecated will be removed 01.06.2026 - use V4\Posting\FbsService::unfulfilledList
+     */
     public function unfulfilledList(array $requestData = []): array
     {
         $default = [

--- a/src/Service/V4/Posting/FbsService.php
+++ b/src/Service/V4/Posting/FbsService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Gam6itko\OzonSeller\Service\V4\Posting;
 
 use Gam6itko\OzonSeller\Enum\PostingScheme;
+use Gam6itko\OzonSeller\Enum\SortDirection;
 use Gam6itko\OzonSeller\Service\AbstractService;
 use Gam6itko\OzonSeller\Utils\ArrayHelper;
 use Gam6itko\OzonSeller\Utils\WithResolver;
@@ -39,8 +40,56 @@ use Gam6itko\OzonSeller\Utils\WithResolver;
  *      product_id: int
  *      quantity: int
  *  }
- *
  * @psalm-type TShipWith = array{additional_data: bool}
+ * @psalm-type TListStatusDate = array{
+ *     from: string,
+ *     to: string
+ *  }
+ * @psalm-type TListFilter = array{
+ *     delivery_method_ids?: int[],
+ *     is_blr_traceable?: bool,
+ *     last_changed_status_date?: TListStatusDate,
+ *     order_id?: int,
+ *     order_numbers?: string[],
+ *     provider_ids?: int[],
+ *     since?: string,
+ *     statuses?: string[],
+ *     to?: string,
+ *     warehouse_ids?: int[]
+ *  }
+ * @psalm-type TListWith = array{
+ *     analytics_data?: bool,
+ *     barcodes?: bool,
+ *     financial_data?: bool,
+ *     legal_info?: bool
+ *  }
+ * @psalm-type TListRequest = array{
+ *     cursor?: string,
+ *     filter?: TListFilter,
+ *     limit?: int,
+ *     sort_dir?: string,
+ *     translit?: bool,
+ *     with?: TListWith,
+ *  }
+ * @psalm-type TUnfulfilledListFilter = array{
+ *     cutoff_from?: string,
+ *     cutoff_to?: string,
+ *     delivering_date_from?: string,
+ *     delivering_date_to?: string,
+ *     delivery_method_ids?: int[],
+ *     last_changed_status_date?: TListStatusDate,
+ *     provider_ids?: int[],
+ *     statuses?: string[],
+ *     warehouse_ids?: int[]
+ *  }
+ * @psalm-type TUnfulfilledListRequest = array{
+ *     cursor?: string,
+ *     filter?: TUnfulfilledListFilter,
+ *     limit?: int,
+ *     sort_dir?: string,
+ *     translit?: bool,
+ *     with?: TListWith,
+ *  }
  */
 class FbsService extends AbstractService
 {
@@ -50,7 +99,7 @@ class FbsService extends AbstractService
      * @see https://docs.ozon.ru/api/seller/#operation/PostingAPI_ShipFbsPostingV4
      *
      * @param $packages list<THasProducts>
-     * @param $with TShipWith
+     * @param $with     TShipWith
      *
      * @return TShipResponse
      */
@@ -68,7 +117,7 @@ class FbsService extends AbstractService
         $body = [
             'packages'       => $packages,
             'posting_number' => $postingNumber,
-            'with' => WithResolver::resolve($with, 4, PostingScheme::FBS, __FUNCTION__),
+            'with'           => WithResolver::resolve($with, 4, PostingScheme::FBS, __FUNCTION__),
         ];
 
         return $this->request('POST', "$this->path/ship", $body);
@@ -87,5 +136,94 @@ class FbsService extends AbstractService
         ];
 
         return $this->request('POST', "$this->path/ship/package", $body);
+    }
+
+    /**
+     * @see https://docs.ozon.ru/api/seller/#operation/PostingFbsList
+     *
+     * @param TListRequest $requestData
+     */
+    public function list(array $requestData = []): array
+    {
+        $default = [
+            'with'     => WithResolver::getDefaults(4, PostingScheme::FBS, 'list'),
+            'filter'   => [],
+            'sort_dir' => SortDirection::ASC,
+            'cursor'   => '',
+            'translit' => true,
+            'limit'    => 10,
+        ];
+
+        $requestData = array_merge(
+            $default,
+            ArrayHelper::pick($requestData, array_keys($default))
+        );
+
+        $requestData['filter'] = ArrayHelper::pick($requestData['filter'], [
+            'delivery_method_ids',
+            'is_blr_traceable',
+            'last_changed_status_date',
+            'order_id',
+            'order_numbers',
+            'provider_ids',
+            'statuses',
+            'since',
+            'to',
+            'warehouse_ids',
+        ]);
+
+        // default filter parameters
+        $requestData['filter'] = array_merge(
+            [
+                'since' => (new \DateTime('now - 7 days'))->format(DATE_W3C),
+                'to'    => (new \DateTime('now'))->format(DATE_W3C),
+            ],
+            $requestData['filter']
+        );
+
+        return $this->request('POST', "{$this->path}/list", $requestData);
+    }
+
+    /**
+     * @see https://docs.ozon.ru/api/seller/#operation/PostingFbsUnfulfilledList
+     *
+     * @param TUnfulfilledListRequest $requestData
+     */
+    public function unfulfilledList(array $requestData = []): array
+    {
+        $default = [
+            'with'        => WithResolver::getDefaults(4, PostingScheme::FBS, 'list'),
+            'filter'      => [],
+            'sort_dir'    => SortDirection::ASC,
+            'cursor'      => '',
+            'translit'    => true,
+            'limit'       => 10,
+        ];
+
+        $requestData = array_merge(
+            $default,
+            ArrayHelper::pick($requestData, array_keys($default))
+        );
+
+        $requestData['filter'] = ArrayHelper::pick($requestData['filter'], [
+            'cutoff_from',
+            'cutoff_to',
+            'delivering_date_from',
+            'delivering_date_to',
+            'delivery_method_ids',
+            'last_changed_status_date',
+            'provider_ids',
+            'statuses',
+            'warehouse_ids',
+        ]);
+
+        if (
+            (empty($requestData['filter']['cutoff_from']) || empty($requestData['filter']['cutoff_to']))
+            && (empty($requestData['filter']['delivering_date_from']) || empty($requestData['filter']['delivering_date_to']))
+        ) {
+            throw new \LogicException('Not defined mandatory filter date ranges `cutoff` or `delivering_date`');
+        }
+
+        return $this->request('POST', "{$this->path}/unfulfilled/list", $requestData);
     }
 }

--- a/src/Utils/WithResolver.php
+++ b/src/Utils/WithResolver.php
@@ -22,6 +22,8 @@ final class WithResolver
             case [3, PostingScheme::FBS, 'ship']:
             case [4, PostingScheme::FBS, 'ship']:
                 return ['additional_data'];
+            case [4, PostingScheme::FBS, 'list']:
+                return ['analytics_data', 'barcodes', 'financial_data', 'legal_info'];
             default:
                 return ['analytics_data', 'barcodes', 'financial_data'];
         }

--- a/tests/Service/V4/Posting/FbsServiceTest.php
+++ b/tests/Service/V4/Posting/FbsServiceTest.php
@@ -154,4 +154,109 @@ final class FbsServiceTest extends AbstractTestCase
             '89491381-0072-1',
         ];
     }
+
+    /**
+     * @covers ::list
+     */
+    public function testList(): void
+    {
+        $this->quickTest(
+            'list',
+            [
+                [
+                    'filter' => [
+                        'since' => '2021-08-01T00:00:00+00:00',
+                        'to'    => '2021-08-08T00:00:00+00:00',
+                    ],
+                ],
+            ],
+            [
+                'POST',
+                '/v4/posting/fbs/list',
+                '{"with":{"analytics_data":false,"barcodes":false,"financial_data":false,"legal_info":false},"filter":{"since":"2021-08-01T00:00:00+00:00","to":"2021-08-08T00:00:00+00:00"},"sort_dir":"asc","translit":true,"cursor":"","limit":10}',
+            ]
+        );
+    }
+
+    /**
+     * @covers ::list
+     */
+    public function testListFilterByStatuses(): void
+    {
+        $this->quickTest(
+            'list',
+            [
+                [
+                    'filter' => [
+                        'since'    => '2021-08-01T00:00:00+00:00',
+                        'to'       => '2021-08-08T00:00:00+00:00',
+                        'statuses' => ['awaiting_packaging', 'delivering'],
+                    ],
+                ],
+            ],
+            [
+                'POST',
+                '/v4/posting/fbs/list',
+                '{"with":{"analytics_data":false,"barcodes":false,"financial_data":false,"legal_info":false},"filter":{"since":"2021-08-01T00:00:00+00:00","to":"2021-08-08T00:00:00+00:00","statuses":["awaiting_packaging","delivering"]},"sort_dir":"asc","translit":true,"cursor":"","limit":10}',
+            ]
+        );
+    }
+
+    /**
+     * @covers ::unfulfilledList
+     */
+    public function testUnfulfilledList(): void
+    {
+        $this->quickTest(
+            'unfulfilledList',
+            [
+                [
+                    'filter' => [
+                        'cutoff_from' => '2021-11-12T00:00:00Z',
+                        'cutoff_to'   => '2021-11-13T00:00:22Z',
+                    ],
+                ],
+            ],
+            [
+                'POST',
+                '/v4/posting/fbs/unfulfilled/list',
+                '{"with":{"analytics_data":false,"barcodes":false,"financial_data":false,"legal_info":false},"filter":{"cutoff_from": "2021-11-12T00:00:00Z","cutoff_to": "2021-11-13T00:00:22Z"},"sort_dir":"asc","translit":true,"cursor":"","limit":10}',
+            ]
+        );
+    }
+
+    /**
+     * * @dataProvider invalidUnfulfilledRequest
+     */
+    public function testUnfulfilledListNoMandatoryFilter(array $methodArguments): void
+    {
+        self::expectException(\LogicException::class);
+        self::expectExceptionMessage('Not defined mandatory filter date ranges `cutoff` or `delivering_date`');
+
+        $svc = new FbsService(
+            [1, 1],
+            $this->createMock(ClientInterface::class),
+            $this->createMock(RequestFactoryInterface::class),
+            $this->createMock(StreamFactoryInterface::class)
+        );
+        $svc->unfulfilledList($methodArguments);
+    }
+
+    public function invalidUnfulfilledRequest(): iterable
+    {
+        $invalidFilters = [
+            [],
+            ['cutoff_from'          => '2021-11-12T00:00:00Z'],
+            ['cutoff_to'            => '2021-11-12T00:00:00Z'],
+            ['delivering_date_from' => '2021-11-12T00:00:00Z'],
+            ['delivering_date_to'   => '2021-11-12T00:00:00Z'],
+            ['cutoff_to'            => '2021-11-12T00:00:00Z', 'delivering_date_to' => '2021-11-12T00:00:00Z'],
+            ['cutoff_to'            => '2021-11-12T00:00:00Z', 'delivering_date_from' => '2021-11-12T00:00:00Z'],
+            ['cutoff_from'          => '2021-11-12T00:00:00Z', 'delivering_date_to' => '2021-11-12T00:00:00Z'],
+            ['cutoff_from'          => '2021-11-12T00:00:00Z', 'delivering_date_from' => '2021-11-12T00:00:00Z'],
+        ];
+        foreach ($invalidFilters as $filter) {
+            yield [['filter' => $filter]];
+        }
+    }
 }


### PR DESCRIPTION
deprecated:
/v3/posting/fbs/list
/v3/posting/fbs/unfulfilled/list

add new methods:
/v4/posting/fbs/list
/v4/posting/fbs/unfulfilled/list